### PR TITLE
Add the rename mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $app->register(new \SilexAssets\Provider\AssetsServiceProvider(array(
     'requirejs_compiled' => $app['assets.require_compiled'],
     'requirejs_output_dir' => __DIR__.'/../web/dist/js',
     'requirejs_web_path' => '/dist/js',
+    'mode' => 'query_string',
 )));
 ```
 
@@ -64,7 +65,22 @@ Then there are twig extensions added that use a very similar syntax to the Asset
 
 ```html
 {% requirejs 'bundles/frontpage' %}
-```  
+```
+
+Cache busting modes
+-------------------
+
+There are who `modes` available.
+
+**query_string** _(default)_
+
+Appends the CRC32 checksum as a query string parameter
+
+**rename**
+
+Rewrites the asset path to the be the CRC32 checksum. The asset's original file extension is preserved.
+
+This mode throws `\SilexAssets\Twig\MissingChecksumException` if there is no manifest entry for an `asset_url`.
 
 
 

--- a/src/SilexAssets/Twig/AssetNode.php
+++ b/src/SilexAssets/Twig/AssetNode.php
@@ -50,11 +50,32 @@ class AssetNode extends \Twig_Node
 
     public function getAssetUrl($asset)
     {
-        if($checksum = $this->_manifest->getChecksum($asset)) {
+        $checksum = $this->_manifest->getChecksum($asset);
+        if ($this->_config['mode'] == 'rename') {
+            return $this->getAssetHashUrl($asset, $checksum);
+        } else {
+            return $this->getAssetQueryStringUrl($asset, $checksum);
+        }
+    }
+
+    private function getAssetQueryStringUrl($asset, $checksum)
+    {
+        if ($checksum) {
             $buster = "?".$checksum;
         } else {
             $buster = "?t".time();
         }
         return $this->_config['web_path'] . '/' . $asset . $buster;
+    }
+
+    private function getAssetHashUrl($asset, $checksum)
+    {
+        if (!$checksum)
+        {
+            throw new \SilexAssets\Twig\MissingChecksumException($asset);
+        }
+
+        $pathinfo = pathinfo($asset);
+        return $this->_config['web_path'] . '/' . $checksum . '.' . $pathinfo['extension'];
     }
 }


### PR DESCRIPTION
## What?

This PR adds the ability to generate hashed asset names, as opposed to query string parameters. The default query string behaviour is maintained.

The renaming mode cannot gracefully fail if a file is missing from the manifest, like the query string mode does, so we throw `\SilexAssets\Twig\MissingChecksumException`.
## Why

This is ideal for having our assets in S3. The current query string approach has an deployment time edge case where users can get newer assets on older versions of the code base.
